### PR TITLE
신고 불가 시 세션값을 FALSE > TRUE로 수정 필요

### DIFF
--- a/modules/comment/comment.controller.php
+++ b/modules/comment/comment.controller.php
@@ -1565,7 +1565,7 @@ class commentController extends comment
 		// failed if both ip addresses between author's and the current user are same.
 		if($oComment->get('ipaddress') == \RX_CLIENT_IP && !$this->user->isAdmin())
 		{
-			$_SESSION['declared_comment'][$comment_srl] = TRUE;
+			$_SESSION['declared_comment'][$comment_srl] = FALSE;
 			return new BaseObject(-1, 'failed_declared');
 		}
 
@@ -1578,7 +1578,7 @@ class commentController extends comment
 			// session registered if the author information matches to the current logged-in user's.
 			if($member_srl && $member_srl == abs($oComment->get('member_srl')))
 			{
-				$_SESSION['declared_comment'][$comment_srl] = TRUE;
+				$_SESSION['declared_comment'][$comment_srl] = FALSE;
 				return new BaseObject(-1, 'failed_declared');
 			}
 		}
@@ -1597,7 +1597,7 @@ class commentController extends comment
 		$log_output = executeQuery('comment.getCommentDeclaredLogInfo', $args);
 		if($log_output->data->count)
 		{
-			$_SESSION['declared_comment'][$comment_srl] = TRUE;
+			$_SESSION['declared_comment'][$comment_srl] = FALSE;
 			return new BaseObject(-1, 'failed_declared');
 		}
 		


### PR DESCRIPTION
안녕하세요!
document.controller.php 에서는 신고 불가 시 세션값이 FALSE로 잘 지정되어 있으나

comment.controller.php 에서만 신고 불가 시 세션값이 TRUE로 저장되도록 되어있어 수정이 필요할 것으로 판단됩니다!