### PR TITLE
색상값을 항상 올바르게 출력하도록 수정

### DIFF
--- a/widgets/content/content.class.php
+++ b/widgets/content/content.class.php
@@ -909,7 +909,7 @@ class contentItem extends BaseObject
 
 		$attrs = array();
 		if($this->get('title_bold') == 'Y') $attrs[] = 'font-weight:bold';
-		if($this->get('title_color') && $this->get('title_color') != 'N') $attrs[] = 'color:#'.$this->get('title_color');
+		if($this->get('title_color') && $this->get('title_color') != 'N') $attrs[] = 'color:#' . ltrim($this->get('title_color'), '#');
 
 		if(count($attrs)) $title = sprintf("<span style=\"%s\">%s</span>", implode(';', $attrs), $title);
 


### PR DESCRIPTION
스킨에서 정상적인 타이틀 색상값을 반환하지 않았을 경우 #을 제거하도록 수정합니다.